### PR TITLE
Alpha credlyuserprofile fix

### DIFF
--- a/includes/credly.php
+++ b/includes/credly.php
@@ -498,8 +498,9 @@ class BadgeOS_Credly {
      */
     public function credly_profile_setting_save( $user_id = 0 ) {
 
-		if ( !current_user_can( 'edit_user', $user_id ) )
+		if ( !current_user_can( 'edit_user', $user_id ) ) {
 			return false;
+		}
 
         $credly_enable = ( ! empty( $_POST['credly_user_enable'] ) && $_POST['credly_user_enable'] == 'true' ? 'true' : 'false' );
 


### PR DESCRIPTION
Adds method to hook that gets run when administrators are saving a user's profile.
