### PR TITLE
Alpha emailnotif fix

### DIFF
--- a/includes/submission-actions.php
+++ b/includes/submission-actions.php
@@ -765,7 +765,7 @@ function badgeos_set_submission_status_submission_pending( $messages, $args ) {
 			To view all submissions, visit: %4$s', 'badgeos' ),
 			get_the_title( $args[ 'achievement_id' ] ),
 			$args[ 'user_data' ]->display_name,
-			html_entity_decode( esc_url_raw( get_edit_post_link( $args[ 'submission_id' ] ) ) ),
+			admin_url( sprintf( 'post.php?post=%d&action=edit', $args[ 'submission_id' ] ) ),
 			admin_url( 'edit.php?post_type=submission' )
 		);
 
@@ -808,7 +808,7 @@ function badgeos_set_submission_status_nomination_pending( $messages, $args ) {
 			get_the_title( $args[ 'achievement_id' ] ),
 			$args[ 'user_data' ]->display_name,
 			$args[ 'from_user_data' ]->display_name,
-			html_entity_decode( esc_url_raw( get_edit_post_link( $args[ 'submission_id' ] ) ) ),
+			admin_url( sprintf( 'post.php?post=%d&action=edit', $args[ 'submission_id' ] ) ),
 			admin_url( 'edit.php?post_type=nomination' )
 		);
 


### PR DESCRIPTION
properly fetches emails stored in our settings, due to nested array. Fixes empty urls in notification emails.
