### PR TITLE
Fixing Grid feature monopolizing render_achievement hook drawback

### DIFF
--- a/includes/ajax-functions.php
+++ b/includes/ajax-functions.php
@@ -149,15 +149,11 @@ function badgeos_ajax_get_achievements() {
 			$args[ 'tag__in' ] = $tag;
 		}
 
-        if ( 'grid' == $layout ) {
-            add_action( 'badgeos_render_achievement', 'badgeos_grid_render_achievement', 10, 2 );
-        }
-
 		// Loop Achievements
 		$achievement_posts = new WP_Query( $args );
 		$query_count += $achievement_posts->found_posts;
 		while ( $achievement_posts->have_posts() ) : $achievement_posts->the_post();
-			$achievements .= badgeos_render_achievement( get_the_ID() );
+			$achievements .= ($layout == 'list')?badgeos_render_achievement( get_the_ID() ) : badgeos_grid_render_achievement( get_the_ID() );
 			$achievement_count++;
 		endwhile;
 

--- a/includes/content-filters.php
+++ b/includes/content-filters.php
@@ -448,7 +448,7 @@ function badgeos_render_achievement( $achievement = 0 ) {
  *
  * @return achievement
  */
-function badgeos_grid_render_achievement( $output, $achievement ) {
+function badgeos_grid_render_achievement( $achievement = 0 ) {
 	global $user_ID;
 
 	// If we were given an ID, get the post
@@ -491,7 +491,7 @@ function badgeos_grid_render_achievement( $output, $achievement ) {
 	$output .= '</div><!-- .badgeos-item-description -->';
 	$output .= '</div><!-- .badgeos-achievements-grid-item -->';
 
-    return $output;
+	return apply_filters( 'badgeos_render_achievement', $output, $achievement->ID );
 }
 
 /**


### PR DESCRIPTION
The way Grid feature was implemented, it was destroying the hook possibilities of badgeos_render_achievement. Plus it was useless to call an action hook from the ajax function in case of grid layout since we just need to call the right function just below with the same test on layout. 
This was we have two functions for rendering, depending on choosen layout, and both are hookable.

And we could even add later more layout if we want using the same approach and adding a "switch" on layout in the ajax function. 

What do you think of that @tw2113 ? 

PS: The addon about setting goals reveals this problem with the hook. #421 