### PR TITLE
On updating a user's points, check if grantee has new awards

### DIFF
--- a/includes/points-functions.php
+++ b/includes/points-functions.php
@@ -59,7 +59,7 @@ function badgeos_update_users_points( $user_id = 0, $new_points = 0, $admin_id =
 
 	// Maybe award some points-based badges
 	foreach ( badgeos_get_points_based_achievements() as $achievement ) {
-		badgeos_maybe_award_achievement_to_user( $achievement->ID );
+		badgeos_maybe_award_achievement_to_user( $achievement->ID, $user_id );
 	}
 
 	return $total_points;


### PR DESCRIPTION
Currently, when calling **badgeos_update_users_points()**, BadgeOS then calls **badgeos_maybe_award_achievement_to_user()** with only the achievement ID parameter, which checks whether the *current user* has earned a new award.

When called by an admin, or if the user is receiving points due to another user's actions, the user granted the new points isn't the current user and so they don't get awarded new badges.

This PR just includes the grantee's user ID when checking for new awards, which covers both granting to the current user and to a separate grantee user.