### PR TITLE
Only populate custom columns for Nominations and Submissions

### DIFF
--- a/includes/submission-actions.php
+++ b/includes/submission-actions.php
@@ -175,6 +175,11 @@ function badgeos_add_nomination_columns( $columns = array() ) {
 function badgeos_submission_column_action( $column = '' ) {
 	global $post;
 
+	// Do not pollute other post types
+	if ( ! in_array( $post->post_type, array( 'submission', 'nomination' ) ) ) {
+		return;
+	}
+
 	switch ( $column ) {
 		case 'action':
 


### PR DESCRIPTION
BadgeOS currently is conflicting when other plugins add post types with any of the same columns as BadgeOS has, for example: `status` or `user`.

To prevent this rather annoying issue, this PR adds a simple post type check before populating anything into the custom columns.