### PR TITLE
added quotation marks to fix issue 446

### DIFF
--- a/includes/achievement-functions.php
+++ b/includes/achievement-functions.php
@@ -613,7 +613,7 @@ function badgeos_get_achievement_earners( $achievement_id = 0 ) {
 	// Grab our earners
 	$earners = new WP_User_Query( array(
 		'meta_key'     => '_badgeos_achievements',
-		'meta_value'   => $achievement_id,
+		'meta_value'   => '"' . $achievement_id . '"',
 		'meta_compare' => 'LIKE'
 	) );
 


### PR DESCRIPTION
Fixes issue #446 . Before a user who earned achievement 23 was also shown when displaying earners of achievement 123.