### PR TITLE
do not treat '0' in meta values as empty

### DIFF
--- a/includes/cmb/helpers/cmb_Meta_Box_types.php
+++ b/includes/cmb/helpers/cmb_Meta_Box_types.php
@@ -231,7 +231,8 @@ class cmb_Meta_Box_types {
 
 		// escaping function passed in?
 		$func       = is_string( $func ) && ! empty( $func ) ? $func : 'esc_attr';
-		$meta_value = ! empty( $meta_value ) ? $meta_value : $field['default'];
+		// do not treat '0' as empty
+		$meta_value = ! empty( $meta_value ) || '0' == $meta_value  ? $meta_value : $field['default'];
 
 		return call_user_func( $func, $meta_value );
 	}

--- a/includes/cmb/init.php
+++ b/includes/cmb/init.php
@@ -581,7 +581,8 @@ class cmb_Meta_Box {
 						self::update_data( $add_new, $name, true );
 					}
 				}
-			} elseif ( ! empty( $new ) && $new != $old  ) {
+			// do not treat '0' as empty
+			} elseif ( ( ! empty( $new ) || '0' == $new ) && $new != $old  ) {
 				$updated[] = $name;
 				self::update_data( $new );
 			} elseif ( empty( $new ) ) {


### PR DESCRIPTION
fixes '0' for maximum earnings being reset on reload