### PR TITLE
Fix use of register_post_type in post-types.php.

### DIFF
--- a/includes/post-types.php
+++ b/includes/post-types.php
@@ -132,7 +132,7 @@ function badgeos_register_post_types() {
 		),
 		'public'             => apply_filters( 'badgeos_public_nominations', false ),
 		'publicly_queryable' => apply_filters( 'badgeos_public_nominations', false ),
-        'capabilities'       => array('manage_options'),
+		'capabilities'       => array('manage_options' => 'manage_options'),
 		'show_ui'            => badgeos_user_can_manage_submissions(),
 		'show_in_menu'       => 'badgeos_badgeos',
 		'show_in_nav_menus'  => apply_filters( 'badgeos_public_nominations', false ),


### PR DESCRIPTION
The capabilities argument of register_post_type requires an associative array of singular to plural capabilities, as the capability_type would be expanded to.  Using a numeric array causes some subtle capability calculation bugs.

See the documentation for [capabilities](https://codex.wordpress.org/Function_Reference/register_post_type#capabilities), indicating that the default value is constructed from [capability_type](https://codex.wordpress.org/Function_Reference/register_post_type#capability_type), which provides an example of the associative array format.